### PR TITLE
updated sql files

### DIFF
--- a/sql_files/build_tables.sql
+++ b/sql_files/build_tables.sql
@@ -4,6 +4,7 @@ CREATE TABLE group14.Property (
     address VARCHAR2(30),
     property VARCHAR2(15),
     primary key (PropertyID));
+    
 
 CREATE TABLE group14.Shop (
     shopID INTEGER,
@@ -11,6 +12,7 @@ CREATE TABLE group14.Shop (
     type VARCHAR2(15),
     buildingID INTEGER,
     income NUMBER(12, 2),
+    foreign key (buildingID) references group14.Property(propertyID),
     primary key (shopID));
 
 
@@ -27,6 +29,8 @@ CREATE TABLE group14.Rental (
     passID varchar2(15),
     rentalTime DATE,
     returnStatus NUMBER(1),
+    foreign key (passID) references group14.Pass(passID),
+    foreign key (equipmentID) references group14.Equipment(equipmentID),
     primary Key (rentalID));
 
 CREATE TABLE group14.Pass (
@@ -36,11 +40,14 @@ CREATE TABLE group14.Pass (
     passType VARCHAR2(15),
     price NUMBER(10,2),
     exprDATE DATE,
+    foreign key (memberID) references group14.Member(memberID),
     primary key (passID));
 
 CREATE TABLE group14.LiftLog (
     passID varchar2(15),
     liftID INTEGER,
+    foreign key (passID) references group14.Pass(passID),
+    foreign key (liftID) references group14.Lift(liftID),
     dateTime DATE);
 
 CREATE TABLE group14.Lift (
@@ -53,9 +60,11 @@ CREATE TABLE group14.Lift (
     primary key (liftID)
     );
 
-CREATE TABLE group14.trailLift (
+CREATE TABLE group14.TrailLift (
     liftID VARCHAR2(15),
-    trailName VARCHAR2(15)
+    trailName VARCHAR2(15),
+    foreign key (trailName) references group14.Trail(name),
+    foreign key (liftID) references group14.Lift(liftID)
     );
 
 CREATE TABLE group14.Trail (
@@ -81,7 +90,8 @@ CREATE TABLE group14.Member (
 
 CREATE TABLE group14.LessonLog (
     orderID INTEGER,
-    dateTime DATE
+    dateTime DATE,
+    foreign key (orderID) references group14.LessonPurchase(orderID)
     );
 
 CREATE TABLE group14.LessonPurchase (
@@ -91,6 +101,8 @@ CREATE TABLE group14.LessonPurchase (
     sessionsPurchased NUMBER(5),
     remainingSessions NUMBER(5),
     price NUMBER(5,2),
+    foreign key (memberID) references group14.Member(memberID),
+    foreign key (lessonID) references group14.LessonOffering(lessonID),
     primary key (orderID)
     );
 
@@ -100,6 +112,7 @@ CREATE TABLE group14.LessonOffering (
     type VARCHAR2(15),
     level VARCHAR2(15),
     schedule VARCHAR2(15),
+    foreign key (instructorID) references group14.Employee(employeeID),
     primary key(lessonID));
 
 CREATE TABLE group14.Employee (
@@ -113,8 +126,14 @@ CREATE TABLE group14.Employee (
     gender VARCHAR2(15),
     ethnicity VARCHAR2(15),
     dateBirth DATE,
-    propertyID INTEGER
+    propertyID INTEGER,
+    foreign key (propertyID) references group14.Property(propertyID),
     primary key (employeeID)
     );
+
+CREATE TABLE group14.Updates (
+    updateType varchar2(15), -- delete or update
+    tableChanged varchar2(25) -- table affected
+);
 
 commit;

--- a/sql_files/insert_employee.sql
+++ b/sql_files/insert_employee.sql
@@ -81,3 +81,5 @@ INSERT INTO group14.Employee VALUES (
     TO_DATE('1992-11-30', 'YYYY-MM-DD'),
     3
 );
+
+commit;

--- a/sql_files/insert_equipment.sql
+++ b/sql_files/insert_equipment.sql
@@ -40,3 +40,5 @@ INSERT INTO group14.Equipment VALUES (
     1
 );
 
+commit;
+

--- a/sql_files/insert_lessonLog.sql
+++ b/sql_files/insert_lessonLog.sql
@@ -2,3 +2,5 @@ INSERT INTO group14.LessonLog VALUES (
     302,
     TO_DATE('2025-04-20 11:00:00', 'YYYY-MM-DD HH24:MI:SS')
 );
+
+commit;

--- a/sql_files/insert_lessonPurchase.sql
+++ b/sql_files/insert_lessonPurchase.sql
@@ -24,3 +24,5 @@ INSERT INTO group14.LessonPurchase VALUES (
     10,
     500.00
 );
+
+commit;

--- a/sql_files/insert_lesson_offering.sql
+++ b/sql_files/insert_lesson_offering.sql
@@ -13,3 +13,5 @@ INSERT INTO group14.LessonOffering VALUES (
     'Intermediate',
     'Fri-Sat 14:00'
 );
+
+commit;

--- a/sql_files/insert_lift.sql
+++ b/sql_files/insert_lift.sql
@@ -24,3 +24,5 @@ INSERT INTO group14.Lift VALUES (
     'Beginner',
     0
 );
+
+commit;

--- a/sql_files/insert_liftlog.sql
+++ b/sql_files/insert_liftlog.sql
@@ -24,6 +24,8 @@ INSERT INTO group14.LiftLog VALUES (
 
 INSERT INTO group14.LiftLog VALUES (
     'P5',
-    'lift3,
+    'lift3',
     TO_DATE('2025-04-15 11:45:00', 'YYYY-MM-DD HH24:MI:SS')
 );
+
+commit;

--- a/sql_files/insert_pass.sql
+++ b/sql_files/insert_pass.sql
@@ -42,4 +42,5 @@ INSERT INTO group14.Pass VALUES (
     49.99,
     TO_DATE('2025-04-30', 'YYYY-MM-DD')
 );
+
 commit;

--- a/sql_files/insert_property.sql
+++ b/sql_files/insert_property.sql
@@ -18,3 +18,5 @@ INSERT INTO group14.Property VALUES (
     '5 Snowcap Trail',
     'Lodge'
 );
+
+commit;

--- a/sql_files/insert_rentals.sql
+++ b/sql_files/insert_rentals.sql
@@ -37,3 +37,5 @@ INSERT INTO group14.Rental VALUES (
     TO_DATE('2025-04-17 13:15:00', 'YYYY-MM-DD HH24:MI:SS'),
     0
 );
+
+commit;

--- a/sql_files/insert_shops.sql
+++ b/sql_files/insert_shops.sql
@@ -57,7 +57,7 @@ INSERT INTO group14.Shop VALUES (
 INSERT INTO group14.Shop VALUES (
     108,
     'Snow Snacks',
-    'Restaraunt',
+    'Restaurant',
     3,
     25123.22
 );
@@ -69,3 +69,5 @@ INSERT INTO group14.Shop VALUES (
     3,
     4665.21
 );
+
+commit;

--- a/sql_files/insert_trailLift.sql
+++ b/sql_files/insert_trailLift.sql
@@ -1,29 +1,31 @@
-INSERT INTO group14.trailLift VALUES (
+INSERT INTO group14.TrailLift VALUES (
     'lift1',
     'Frosty Pines'
 );
 
-INSERT INTO group14.trailLift VALUES (
+INSERT INTO group14.TrailLift VALUES (
     'lift1',
     'Mogul Mayhem'
 );
 
-INSERT INTO group14.trailLift VALUES (
+INSERT INTO group14.TrailLift VALUES (
     'lift3',
     'Snow Garden'
 );
 
-INSERT INTO group14.trailLift VALUES (
+INSERT INTO group14.TrailLift VALUES (
     'lift3',
     'Chilly Canyon'
 );
 
-INSERT INTO group14.trailLift VALUES (
+INSERT INTO group14.TrailLift VALUES (
     'lift2',
     'Powder Playground'
 );
 
-INSERT INTO group14.trailLift VALUES (
+INSERT INTO group14.TrailLift VALUES (
     'lift2',
     'Icicle Twist'
 );
+
+commit;

--- a/sql_files/insert_trails.sql
+++ b/sql_files/insert_trails.sql
@@ -51,3 +51,5 @@ INSERT INTO group14.Trail VALUES (
     1,
     'Intermediate'
 );
+
+commit;


### PR DESCRIPTION
added foreign key constraints
added "commit;" to each file

Because of PK-FK constraints tables must have data added in following order:
(other orders possible this is just what I found)

1) Property → used by Shop, Employee
2) Employee → used by LessonOffering
3) Equipment → used by Rental
4) Trail → used by TrailLift
5) Lift → used by LiftLog, TrailLift
6) TrailLift
7) Shop
8) Member → used by Pass, LessonPurchase
9) Pass → used by Rental, LiftLog
10) LessonOffering → used by LessonPurchase
11) LessonPurchase → used by LessonLog
12) Rental
13) LiftLog
14) LessonLog